### PR TITLE
Add Read Me file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^\.github$
+^README\.Rmd$

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,43 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# iucnredlist
+
+<!-- badges: start -->
+<!-- badges: end -->
+
+The International Union for Conservation of Nature’s Red List of Threatened Species has evolved to become the world’s most comprehensive information source on the global conservation status of animal, fungi and plant species. It's a critical indicator of the health of the world’s biodiversity.
+
+The IUCN Redlist application is a Ruby on Rails application that is designed to be a tool to help inform and catalyze action for biodiversity conservation and policy change, critical to protecting the natural resources we need to survive. Through a web-browser - and also via a machine readable API - it provides information about range, population size, habitat and ecology, use and/or trade, threats, and conservation actions that will help inform necessary conservation decisions.
+
+The goal of the `iucnredlist` R package is to ...
+
+## Installation
+
+You can install the development version of iucnredlist from [GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("IUCN-UK/iucnredlist")
+```
+
+## Example
+
+This is a basic example which shows you how to solve a common problem:
+
+```{r example}
+library(iucnredlist)
+## basic example code
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+# iucnredlist
+
+<!-- badges: start -->
+<!-- badges: end -->
+
+The International Union for Conservation of Nature’s Red List of
+Threatened Species has evolved to become the world’s most comprehensive
+information source on the global conservation status of animal, fungi
+and plant species. It’s a critical indicator of the health of the
+world’s biodiversity.
+
+The IUCN Redlist application is a Ruby on Rails application that is
+designed to be a tool to help inform and catalyze action for
+biodiversity conservation and policy change, critical to protecting the
+natural resources we need to survive. Through a web-browser - and also
+via a machine readable API - it provides information about range,
+population size, habitat and ecology, use and/or trade, threats, and
+conservation actions that will help inform necessary conservation
+decisions.
+
+The goal of the `iucnredlist` R package is to …
+
+## Installation
+
+You can install the development version of iucnredlist from
+[GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("IUCN-UK/iucnredlist")
+```
+
+## Example
+
+This is a basic example which shows you how to solve a common problem:
+
+``` r
+library(iucnredlist)
+## basic example code
+```

--- a/tests/testthat/test-iucnredlist.R
+++ b/tests/testthat/test-iucnredlist.R
@@ -1,3 +1,4 @@
+# An example test - this will be removed
 test_that("multiplication works", {
   expect_equal(2 * 2, 4)
 })


### PR DESCRIPTION
This PR adds a Read Me file to the package.  It was generated by first running `use_readme_rmd()` in a RStudio terminal, edits made to the `README.Rmd` file made, followed by `build_readme()`

Some notes removed from the `README.Rmd` file:

What is special about using `README.Rmd` instead of just `README.md`? You can include R chunks like so:

```{r cars}
summary(cars)
```

You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this.

You can also embed plots, for example:

```{r pressure, echo = FALSE}
plot(pressure)
```

In that case, don't forget to commit and push the resulting figure files, so they display on GitHub and CRAN.