### PR TITLE
Capture httr2 errors

### DIFF
--- a/R/assessment_data.R
+++ b/R/assessment_data.R
@@ -15,17 +15,23 @@ assessment_data <- function(api, assessment_id) {
 
   tryCatch(
     {
-      req <- api %>%
+      request <- api %>%
         httr2::req_url(url) %>%
         httr2::req_perform()
 
-      httr2::resp_body_json(req)
+      httr2::resp_body_json(request)
     },
-    httr2_http_401 = function(e) {
+    httr2_http_401 = function(error) {
       cat("Error 401: Unauthorized. This error may occur if your Red List API token was copied incorrectly. You can retrieve your API token at https://api.iucnredlist.org/users/edit\n")
+      NULL
+    },
+    httr2_http_error = function(error) {
+      cat("HTTP Error:", error$message, "\n")
+      NULL
     },
     error = function(error) {
       cat("An unexpected error occurred:", error$message, "\n")
+      NULL
     }
   )
 }


### PR DESCRIPTION
This PR adds refactors the `assessment_data` function to gracefully handle errors like connection failures or other non-200 status codes.  It also adds a specific error class for handling `401 Unauthorized` httr2 errors - outputting a custom message prompting the user to double check their API token is correct with a link to the API user account page.  It uses `tryCatch()` to handle errors and exceptions during runtime with specific error types (in this case any non 200 codes or other erros) caught and handled with a custom function:
* `httr2_http_401` is an error class for handling `401 Unauthorized` errors - it outputs a custom message prompting the user to check their user account with a https link to the API user account page.
* `httr2_http_error`is an error class for handling all HTTP status codes that are not 200 or 401
* `error` is a a generic handler for all other R errors.

