### PR TITLE
Alias rlang binary infix

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,5 @@
+`%||%` <- rlang::`%||%`
+
 ##########################
 ### INTERNAL FUNCTIONS ###
 ##########################
@@ -165,9 +167,4 @@ nested_list_to_tibble <- function(input_list) {
     actions %>%
       dplyr::mutate(name = top_name)
   })
-}
-
-# Custom binary infix operator
-`%||%` <- function(lhs, rhs) {
-  if (!is.null(lhs)) lhs else rhs
 }


### PR DESCRIPTION
This PR aliases `rlang`'s binary infix operator `%||%` so we can remove the custom function. 